### PR TITLE
feat: add office-based project visibility

### DIFF
--- a/Controllers/Manteinance/ProjectsController.cs
+++ b/Controllers/Manteinance/ProjectsController.cs
@@ -53,6 +53,23 @@ namespace TimeTracker.Controllers.Manteinance
                     db.SaveChanges();
                 }
 
+                var users = formCollection["cboUsers"];
+                if (!string.IsNullOrEmpty(users))
+                {
+                    var userModel = db.UsersProject;
+                    var selected = users.Split(',');
+                    foreach (var item in selected)
+                    {
+                        UsersProject up = new UsersProject();
+                        up.Project = newProject;
+                        int uId = Convert.ToInt32(item);
+                        var u = db.Users.Where(x => x.UserId == uId).FirstOrDefault();
+                        up.Users = u;
+                        userModel.Add(up);
+                    }
+                    db.SaveChanges();
+                }
+
 
             }
             catch (Exception ex)
@@ -104,6 +121,27 @@ namespace TimeTracker.Controllers.Manteinance
                         PmsModel.Add(projectManager);
                         db.SaveChanges();
                     }
+                }
+
+                var userModel = db.UsersProject;
+                var actualUsers = db.UsersProject.Where(x => x.Project.ProjectId == ProjectId).ToList();
+                userModel.RemoveRange(actualUsers);
+                db.SaveChanges();
+
+                var users = formCollection["cboEUsers"];
+                if (!string.IsNullOrEmpty(users))
+                {
+                    var selected = users.Split(',');
+                    foreach (var item in selected)
+                    {
+                        UsersProject up = new UsersProject();
+                        up.Project = newProject;
+                        int uId = Convert.ToInt32(item);
+                        var u = db.Users.Where(x => x.UserId == uId).FirstOrDefault();
+                        up.Users = u;
+                        userModel.Add(up);
+                    }
+                    db.SaveChanges();
                 }
 
 
@@ -167,13 +205,19 @@ namespace TimeTracker.Controllers.Manteinance
             {
                 int ProjectId = Convert.ToInt32(id);
                 var data = db.Project.Where(x => x.ProjectId == ProjectId).FirstOrDefault();
-                var PMs = db.ProjectManager.Where(x=> x.Project.ProjectId == ProjectId).ToList();
+                var PMs = db.ProjectManager.Where(x => x.Project.ProjectId == ProjectId).ToList();
                 List<int> pmsList = new List<int>();
                 foreach (var item in PMs)
                 {
                     pmsList.Add(item.Users.UserId);
                 }
-                return Json(new { data.ProjectId, data.ProjectName, data.CreateUser, data.CreateDate, data.Customer.CustomerId, data.color, pms = pmsList }, JsonRequestBehavior.AllowGet);
+                var UPs = db.UsersProject.Where(x => x.Project.ProjectId == ProjectId).ToList();
+                List<int> users = new List<int>();
+                foreach (var item in UPs)
+                {
+                    users.Add(item.Users.UserId);
+                }
+                return Json(new { data.ProjectId, data.ProjectName, data.CreateUser, data.CreateDate, data.Customer.CustomerId, data.color, pms = pmsList, users }, JsonRequestBehavior.AllowGet);
             }
             catch (Exception ex)
             {

--- a/Controllers/Security/UsersController.cs
+++ b/Controllers/Security/UsersController.cs
@@ -42,6 +42,12 @@ namespace TimeTracker.Controllers.Security
 
                 Company company = db.Company.FirstOrDefault();
                 newUsers.Company = company;
+                int officeId = Convert.ToInt32(formCollection["OfficeId"]);
+                if (officeId > 0)
+                {
+                    var office = db.Office.FirstOrDefault(x => x.OfficeId == officeId);
+                    newUsers.Office = office;
+                }
                 string mail = formCollection["Email"];
                 newUsers.Email = mail;
                 newUsers.UserName = formCollection["UserName"];
@@ -60,6 +66,19 @@ namespace TimeTracker.Controllers.Security
 
                 model.Add(newUsers);
                 db.SaveChanges();
+
+                if (officeId > 0)
+                {
+                    var officeProjects = db.Project.Where(p => p.Customer.Office.OfficeId == officeId).ToList();
+                    foreach (var proj in officeProjects)
+                    {
+                        UsersProject up = new UsersProject();
+                        up.Project = proj;
+                        up.Users = newUsers;
+                        db.UsersProject.Add(up);
+                    }
+                    db.SaveChanges();
+                }
 
                 var Roles = formCollection["cboRole"].Split(',');
                 
@@ -114,6 +133,12 @@ namespace TimeTracker.Controllers.Security
 
                 Company company = db.Company.FirstOrDefault();
                 newUsers.Company = company;
+                int officeId = Convert.ToInt32(formCollection["eOfficeId"]);
+                if (officeId > 0)
+                {
+                    var office = db.Office.FirstOrDefault(x => x.OfficeId == officeId);
+                    newUsers.Office = office;
+                }
                 newUsers.Email = formCollection["eEmail"];
                 newUsers.UserName = formCollection["eUserName"];
                 newUsers.FirstName = formCollection["eFirstName"];
@@ -127,6 +152,24 @@ namespace TimeTracker.Controllers.Security
 
                 db.Entry(newUsers).State = System.Data.Entity.EntityState.Modified;
                 db.SaveChanges();
+
+                if (officeId > 0)
+                {
+                    var userProjects = db.UsersProject.Where(x => x.UserId == UsersId).ToList();
+                    db.UsersProject.RemoveRange(userProjects);
+                    db.SaveChanges();
+
+                    var officeProjects = db.Project.Where(p => p.Customer.Office.OfficeId == officeId).ToList();
+                    foreach (var proj in officeProjects)
+                    {
+                        UsersProject up = new UsersProject();
+                        up.Project = proj;
+                        up.Users = newUsers;
+                        db.UsersProject.Add(up);
+                    }
+                    db.SaveChanges();
+                }
+
                 var RoleModel = db.RolesUsers;
                 var _roles = db.RolesUsers.Where(x => x.Users.UserId == UsersId).ToList();
                 RoleModel.RemoveRange(_roles);
@@ -207,7 +250,7 @@ namespace TimeTracker.Controllers.Security
                 var data = db.Users.Where(x => x.UserId == id).FirstOrDefault();
                 var role = db.RolesUsers.Where(z => z.Users.UserId == id).Select(x=> x.Roles.RoleId).ToList();
                 
-                return Json(new { data.UserId, data.Email, data.Company.CompanyId, data.UserName, data.FirstName, data.Active, data.LastName, role }, JsonRequestBehavior.AllowGet);
+                return Json(new { data.UserId, data.Email, data.Company.CompanyId, data.UserName, data.FirstName, data.Active, data.LastName, role, data.OfficeId }, JsonRequestBehavior.AllowGet);
             }
             catch (Exception ex)
             {

--- a/Models/Users.cs
+++ b/Models/Users.cs
@@ -40,8 +40,10 @@ namespace TimeTracker.Models
         public bool IsSuperUser { get; set; }
         public byte[] ProfilePict { get; set; }
         public System.DateTime FactorEndDate { get; set; }
+        public Nullable<int> OfficeId { get; set; }
     
         public virtual Company Company { get; set; }
+        public virtual Office Office { get; set; }
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]
         public virtual ICollection<ProjectManager> ProjectManager { get; set; }
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2227:CollectionPropertiesShouldBeReadOnly")]

--- a/Scripts/Manteinance/Project.js
+++ b/Scripts/Manteinance/Project.js
@@ -133,9 +133,10 @@ $("#projects").on("click", ".btnEditProject", function () {
             console.log(Project.pms);
             $("#EdProjectId").val(Project.ProjectId);
             $("#EdProjectName").val(Project.ProjectName);
-            $("#cboECustomer").val(Project.CustomerId); 
-            $("#ecolor").asColorPicker('val', Project.color); 
-            $("#cboEPM").val(Project.pms).trigger('change'); 
+            $("#cboECustomer").val(Project.CustomerId);
+            $("#ecolor").asColorPicker('val', Project.color);
+            $("#cboEPM").val(Project.pms).trigger('change');
+            $("#cboEUsers").val(Project.users).trigger('change');
         },
         timeout: 30 * 60 * 1000
     }).fail(function (xhr, status) {

--- a/Scripts/Security/Users.js
+++ b/Scripts/Security/Users.js
@@ -69,6 +69,7 @@ $("#users-list").on("click", ".btnEditUsers", function () {
             $("#eUsername").val(data.UserName);
             $("#eFirstName").val(data.FirstName);
             $("#eLastName").val(data.LastName);
+            $("#eOfficeId").val(data.OfficeId).trigger('change');
             if (data.Active) {
                 $("#customCheck").attr('checked');
             } else {

--- a/Views/Manteinance/Projects/_ListProject.cshtml
+++ b/Views/Manteinance/Projects/_ListProject.cshtml
@@ -96,6 +96,11 @@
                             @Html.Action("GetCboPM", "System")
                         </div>
 
+                        <div class="modal-body">
+                            <label for="email">Users</label>
+                            @Html.Action("GetCboUsers", "System")
+                        </div>
+
 
 
 
@@ -162,6 +167,11 @@
                             <label for="email">Project Manager</label>
                             @Html.Action("GetCboEPM", "System")
 
+                        </div>
+
+                        <div class="modal-body">
+                            <label for="email">Users</label>
+                            @Html.Action("GetECboUsers", "System")
                         </div>
 
                         <br>

--- a/Views/Security/Users/_ListUsers.cshtml
+++ b/Views/Security/Users/_ListUsers.cshtml
@@ -103,6 +103,11 @@
                             @Html.Action("GetCboMultipleRoles", "System")
                         </div>
 
+                        <div class="modal-body">
+                            <label for="OfficeId">Office</label>
+                            @Html.Action("GetCboOffice", "System")
+                        </div>
+
 
 
                         <div class="modal-body">
@@ -171,6 +176,10 @@
                         <div class="modal-body">
                             <label for="Active">Roles </label>
                             @Html.Action("GetCboEMultipleRoles", "System")
+                        </div>
+                        <div class="modal-body">
+                            <label for="eOfficeId">Office</label>
+                            @Html.Action("GetECboOffice", "System")
                         </div>
                         <div class="modal-body">
 

--- a/Views/System/_cboEUsers.cshtml
+++ b/Views/System/_cboEUsers.cshtml
@@ -5,7 +5,7 @@
     List<Users> users = Model;
 }
 
-<select class="custom-select2 form-control" id="cboEUsers" name="cboEUsers" style="width: 100%; height: 38px">
+<select class="custom-select2 form-control" id="cboEUsers" name="cboEUsers" multiple="multiple" style="width: 100%">
     @foreach (var item in users)
     {
         string fullname = item.FirstName + " " + item.LastName;

--- a/Views/System/_cboUsers.cshtml
+++ b/Views/System/_cboUsers.cshtml
@@ -4,8 +4,7 @@
     List<Users> users = Model;
 }
 
-<select class="custom-select2 form-control" id="cboUsers" name="cboUsers" style="width: 100%; height: 38px">
-    <option value=""> </option>
+<select class="custom-select2 form-control" id="cboUsers" name="cboUsers" multiple="multiple" style="width: 100%">
     @foreach (var item in users)
     {
         string fullname = item.FirstName + " " + item.LastName;


### PR DESCRIPTION
## Summary
- add Office assignment to users with automatic project links by office
- allow project creation/edit to attach users and keep mappings updated
- expose office selection fields and multi-user pickers in maintenance views

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_68a7879c31208324b5d5feee3693ec27